### PR TITLE
Add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.idea


### PR DESCRIPTION
JetBrains IDEs, notably RustRover, create files under .idea that are helpful to be ignored.