### PR TITLE
Use UTF-8 paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,6 @@ versioninfo = []
 manifest = []
 
 [dependencies]
-build_cfg = { version = "1.1.0", optional = true }
-embed-resource = { version = "2.4", optional = true }
+build_cfg = { version = "1", optional = true }
+camino = "1"
+embed-resource = { version = "2", optional = true }

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ In `build.rs`
 ```rust
 extern crate windows_exe_info;
 fn main(){
-    windows_exe_info::icon::icon_ico(std::path::Path::new("PATH/TO/ICON.ico"));
+    windows_exe_info::icon::icon_ico("PATH/TO/ICON.ico");
 }
 ```
 
@@ -139,6 +139,6 @@ In `build.rs`
 ```rust
 extern crate windows_exe_info;
 fn main(){
-    windows_exe_info::manifest::manifest(std::path::Path::new("PATH/TO/MANIFEST.XML"));
+    windows_exe_info::manifest::manifest("PATH/TO/MANIFEST.XML");
 }
 ```

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,3 +1,4 @@
+use camino::Utf8Path;
 #[cfg(feature = "build_cfg")]
 const WINDRES_COMMAND: &str = "-i [INPUT] -O coff -F [ARCH] -o [OUTPUT] -v";
 #[cfg(not(feature = "build_cfg"))]
@@ -9,7 +10,8 @@ use std::cfg as build_cfg;
 #[cfg(not(feature = "embed_resource"))]
 use std::process::Command;
 
-pub fn link(resource_path: String) {
+pub fn link<P: AsRef<Utf8Path>>(resource_path: P) {
+    let resource_path = resource_path.as_ref();
     #[cfg(feature = "windows_only")]
     if let Err(error) = std::env::var("CARGO_CFG_WINDOWS") {
         // quit if variable does not exist as we are not targeting windows
@@ -26,7 +28,7 @@ pub fn link(resource_path: String) {
     {
         let resource_file = format!("{resource_path}.a");
         let args = WINDRES_COMMAND
-            .replace("[INPUT]", &resource_path)
+            .replace("[INPUT]", resource_path.as_str())
             .replace("[OUTPUT]", &resource_file);
 
         #[cfg(feature = "build_cfg")]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,14 +1,15 @@
 use std::env::var;
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::path::Path;
+use camino::Utf8Path;
 
 const MANIFEST_RESOURCE_SCRIPT: &str = "#define RT_MANIFEST 24
 [ID] RT_MANIFEST \"[PATH]\"\n";
 pub(crate) static mut CURRENT_MANIFEST_ID: u16 = 0;
 
 /// adds an application manifest to an executable
-pub fn manifest(path: &Path) {
+pub fn manifest<P: AsRef<Utf8Path>>(path: P) {
+    let path = path.as_ref();
     assert!(path.exists(), "Path does not exist");
 
     let output_dir = var("OUT_DIR").unwrap();
@@ -23,7 +24,7 @@ pub fn manifest(path: &Path) {
     let resource_script_content = MANIFEST_RESOURCE_SCRIPT
         .replace(
             "[PATH]",
-            &path.to_str().map(|path| path.replace('\\', "/")).unwrap(),
+            &path.as_str().replace('\\', "/"),
         )
         .replace("[ID]", &unsafe { format!("manifest{CURRENT_MANIFEST_ID}") });
     unsafe {


### PR DESCRIPTION
This pull request replaces paths to be guaranteed UTF-8 and allows more types than just Path to be passed into functions:

1. This adds [camino](https://github.com/camino-rs/camino) which is a library that provides a small wrapper around the standard library Path but guarantees that it can only contain valid UTF-8. It's like how Path is akin to OsStr; UTF8Path is akin to str. It's clear from the current code that the library is expecting UTF-8 anyway as `path.to_str().unwrap()` is used a lot. This means we can now just do `path.as_str()` which means we prevent some potential panics.
```rust
// Standard Library path
&path.to_str().map(|path| path.replace('\\', "/")).unwrap(),
// UTF-8 Path
&path.as_str().replace('\\', "/"),
```
2. This changes the parameters for path from `&Path` to `AsRef<UTF8Path>`. This means that users can input more than just the path type as long as it can reference into a path. This means they'll now accept standard library paths, owned strings, borrowed strings, etc.