### PR TITLE
Replace unsafe mutable statics with atomics

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::Ordering;
 #[cfg(feature = "versioninfo")]
 use crate::versioninfo::*;
 
@@ -78,9 +79,9 @@ fn format_version_info() {
     assert_eq!(rc.to_string(), FORMATTED_VERSIONINFO);
 
     // check double linking prevention
-    assert!(!unsafe { HAS_LINKED_VERSIONINFO });
+    assert!(!HAS_LINKED_VERSION_INFO.load(Ordering::Relaxed));
     rc.link().unwrap();
-    assert!(unsafe { HAS_LINKED_VERSIONINFO });
+    assert!(HAS_LINKED_VERSION_INFO.load(Ordering::Relaxed));
     assert!(rc.link().is_err());
 
     // cleanup
@@ -147,8 +148,5 @@ fn multi_icon_id() {
     std::fs::remove_file(&temp_file).unwrap();
 
     // check (2)
-    unsafe {
-        let current_icon_id = CURRENT_ICON_ID;
-        assert_eq!(current_icon_id, ITERATIONS);
-    }
+    assert_eq!(CURRENT_ICON_ID.load(Ordering::Relaxed), ITERATIONS);
 }


### PR DESCRIPTION
This pull request removes all internal usages of unsafe (global mutable statics) in favour of atomic equivalents.

Before this change, I can see the potential for undefined behaviour if the link function is called more than once over multiple threads. Whilst that would be a gross misuse of this library, there's no harm in using atomics as atomics with relaxed ordering [don't have any overhead](https://stackoverflow.com/a/72369696). If this was ever more of a concern, there are more strict orderings that guarantee when other threads will see any change to the atomic.

Functionally, there shouldn't be any difference with this change; it merely aims to remove unnecessary usages of unsafe.

See https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html